### PR TITLE
Login process update to work with ACE

### DIFF
--- a/cNetwork.cpp
+++ b/cNetwork.cpp
@@ -13,7 +13,7 @@ bool SockCompare(SOCKADDR_IN *a, SOCKADDR_IN *b)
 		(a->sin_port != b->sin_port)
 		&&
 		(a->sin_port != b->sin_port + 0x0100)
-		//Loginserver is retarded and sends from one port higher sometimes, so we have to account
+		// XXX: Loginserver is retarded and sends from one port higher sometimes, so we have to account
 		//		and allow for that...
 		)
 		) return false;
@@ -40,7 +40,7 @@ cNetwork::cNetwork()
 	bPortalMode = false;
 
 	int iError = SOCKET_ERROR;
-	int iSrcPort = 9010;
+	int iSrcPort = 0; // binding to port "0" tells winsock to get a random open port
 	while (iError == SOCKET_ERROR)
 	{
 		siSockAddr.sin_port = htons( iSrcPort );
@@ -54,27 +54,49 @@ cNetwork::cNetwork()
 	char acServerIP[32];
 	int acServerPort = 0;
 
+	/* parse command line arguments */
+	/* the options are the same as the original client */
 	for (int arg=0; arg < __argc; arg++)
 	{
+		/* options always have two characters and start with '-' */
 		if (strlen(__argv[arg]) != 2) { continue; }
 		if (__argv[arg][0] == '-')
 		{
 			switch (__argv[arg][1])
 			{
+				/* server IP address */
 				case 'h':
 				{
 					if (arg + 1 < __argc) {
 						strcpy(acServerIP, __argv[arg+1]);
-						acServerPort = atoi(strchr(acServerIP,':')+1);
-						*strchr(acServerIP,':') = 0;
 					}
 					break;
 				}
+				/* port number */
+				case 'p':
+				{
+					if (arg + 1 < __argc) {
+						acServerPort = atoi(__argv[arg+1]);
+					}
+					break;
+				}
+
+				/* account */
 				case 'a':
 				{
 					if (arg + 1 < __argc) {
 						ZeroMemory(m_zAccountName, 40);
 						strcpy(m_zAccountName, __argv[arg+1]);
+						// check if password is provided
+						char* password_index = strchr(m_zAccountName, ':');
+						if (password_index == NULL) {
+							m_zPassword[0] = 0;
+						} else {
+							strcpy(m_zPassword, password_index + 1);
+							// end account name string at the colon
+							*password_index = 0;
+						}
+						
 					}
 					break;
 				}
@@ -82,15 +104,21 @@ cNetwork::cNetwork()
 		}
 	}
 
-	HKEY hkTicket;
-	if (!RegOpenKey(HKEY_CURRENT_USER,"Software\\Turbine\\AC1",&hkTicket))
-	{
-		m_zTicketSize = 0xf4;
-		DWORD tpout = 0x100;
-		if (RegQueryValueEx(hkTicket, "GLSTicket", NULL, NULL, m_zTicket, &tpout))
+	if (m_zPassword[0] == 0) {
+		// password wasn't provided at command line so use GLSTicket
+		HKEY hkTicket;
+		if (!RegOpenKey(HKEY_CURRENT_USER, "Software\\Turbine\\AC1", &hkTicket))
 		{
-            MessageBox(NULL, "GLSTicket not found!", "Error", MB_OK);
+			m_zTicketSize = 0xf4;
+			DWORD tpout = 0x100;
+			if (RegQueryValueEx(hkTicket, "GLSTicket", NULL, NULL, m_zTicket, &tpout))
+			{
+				MessageBox(NULL, "GLSTicket not found!", "Error", MB_OK);
+			}
 		}
+	}
+	else {
+		m_zTicketSize = 0;
 	}
 
 	m_siLoginServer.m_saServer.sin_family = AF_INET;
@@ -314,6 +342,7 @@ static DWORD checksumPacket(cPacket *packet, ChecksumXorGenerator * xorGen)
     return checksumHeader(*header) + (checksumContent(*header, packet->GetPayload()) ^ xorVal);
 }
 
+/* Send packet to login server */
 void cNetwork::SendLSPacket(cPacket *Packet, bool IncludeSeq, bool IncrementSeq)
 {
 	stTransitHeader *Head = Packet->GetTransit();
@@ -380,19 +409,18 @@ void cNetwork::SendLostPacket(int iSendSequence, stServerInfo *Target)
 
 void cNetwork::SendPacket(cPacket *Packet, stServerInfo *Target)
 {
-//	m_Interface->OutputConsoleString("Sending Packet: %i to %s:%i", Packet->GetTransit()->m_dwSequence, inet_ntoa(Target->m_saServer.sin_addr), htons(Target->m_saServer.sin_port));
-
 	BYTE *pbData = Packet->GetData();
 	int iLength = Packet->GetLength();
 
-    if (Packet->GetTransit()->m_dwFlags == kConnectResponse)
+    // server wants connect response on next higher port
+	if (Packet->GetTransit()->m_dwFlags == kConnectResponse)
     {
         Target->m_saServer.sin_port = htons(Target->m_wBasePort + 1);
-    }
-    else
-    {
+    } else {
         Target->m_saServer.sin_port = htons(Target->m_wBasePort);
     }
+
+	//m_Interface->OutputConsoleString("Sending Packet: Seq: %i, Dest: %s:%i", Packet->GetTransit()->m_dwSequence, inet_ntoa(Target->m_saServer.sin_addr), htons(Target->m_saServer.sin_port));
 
 	int tp = sendto(m_sSocket, (char *) pbData, iLength, NULL, (SOCKADDR *)&Target->m_saServer, sizeof( SOCKADDR ) );
 
@@ -411,6 +439,7 @@ void cNetwork::SendPacket(cPacket *Packet, stServerInfo *Target)
 		Target->m_dwLastPacketSent = GetTickCount();
 		Unlock();	
 	}
+
 }
 
 void cNetwork::SetInterface(cInterface *Interface)
@@ -447,16 +476,33 @@ void cNetwork::Connect()
     stTransitHeader header;
     header.m_dwFlags = 0x00010000;
     LoginPacket->Add(&header, sizeof(stTransitHeader));
-    LoginPacket->Add(std::string("1802"));
-    LoginPacket->Add((DWORD)0x00000116);    //Actually a size of data left?
-    LoginPacket->Add((DWORD)0x40000002);
-    LoginPacket->Add((DWORD)0);
-    LoginPacket->Add((DWORD)time(NULL));
-    LoginPacket->Add(std::string(m_zAccountName));
-	LoginPacket->Add((DWORD) 0);
-	LoginPacket->Add((DWORD) 0x000000F6);
-	LoginPacket->Add((WORD) 0xF480);
-	LoginPacket->Add(m_zTicket, m_zTicketSize);
+    LoginPacket->Add(std::string("1802")); // magic string
+	// Data length left in packet including ticket (FIXME: calculate this, but ACEmulator doesn't seem to care)
+	if (m_zPassword[0] != 0) {
+		LoginPacket->Add((DWORD)0x00000020);
+	} else {
+		LoginPacket->Add((DWORD)0x00000116);    
+	}
+	// Authentication Type
+	if (m_zPassword[0] != 0) {
+		LoginPacket->Add((DWORD)kAuthAccountPassword);
+	} else {
+		LoginPacket->Add((DWORD)kAuthGlsTicket);
+	}
+    LoginPacket->Add((DWORD)0x00000000);  // Authentication Flags 
+    LoginPacket->Add((DWORD)time(NULL)); // Timestamp
+    LoginPacket->Add(std::string(m_zAccountName)); // Account name
+
+	// Empty string for special admin account name
+	LoginPacket->Add(std::string());
+
+	if (m_zPassword[0] != 0) {
+		LoginPacket->AddString32L(std::string(m_zPassword)); // Password uses weird 32L format
+	} else {
+		LoginPacket->Add((DWORD)0x000000F6);
+		LoginPacket->Add((WORD)0xF480);
+		LoginPacket->Add(m_zTicket, m_zTicketSize);
+	}
 
 	SendLSPacket(LoginPacket, true, false);
 
@@ -584,14 +630,17 @@ void cNetwork::CheckPings()
 
 void cNetwork::Run()
 {
+	unsigned int TIMEOUT_MS = 1000;
 	//message loop for the network thread
 	while (!m_bQuit)
 	{
 		//keep trying to connect to login server if first time doesn't work
 		if (!(m_siLoginServer.m_dwFlags & SF_CONNECTED))
 		{
-			if ((m_siLoginServer.m_dwLastConnectAttempt + 10000) < GetTickCount())
+			// timeout trying to connect
+			if ((m_siLoginServer.m_dwLastConnectAttempt + TIMEOUT_MS) < GetTickCount())
 			{
+				m_Interface->OutputConsoleString("Timed out after %d ms.", TIMEOUT_MS);
 				m_Interface->OutputConsoleString("Couldn't connect first time, trying again..");
 				Connect();
 			}
@@ -632,7 +681,7 @@ void cNetwork::Run()
 				char tps[50];
 				char *tps2 = inet_ntoa(m_siLoginServer.m_saServer.sin_addr);
 				strcpy(tps, tps2);
-				m_Interface->OutputConsoleString("Unknown Target: %s:%i.  LS: %s:%i"
+				m_Interface->OutputConsoleString("Unknown Target: %s:%i.  Login server: %s:%i"
 					, inet_ntoa(tp->sin_addr)
 					, (int)ntohs(tp->sin_port)
 					, tps
@@ -694,8 +743,11 @@ void cNetwork::ProcessLSPacket(cPacket *Packet)
         dwFlags &= ~kAckSequence;
     }
 
+	// Second step of the connection process is to receive a Connect Request packet from the server
     if (dwFlags & kConnectRequest)
     {
+		m_Interface->OutputConsoleString("Received connection request from server...");
+
         // Connection request from the server
         m_siLoginServer.m_wTable = Head->m_wTable;
         m_siLoginServer.m_dwLastSyncRecv = GetTickCount();
@@ -703,8 +755,8 @@ void cNetwork::ProcessLSPacket(cPacket *Packet)
         m_siLoginServer.m_dwFlags |= SF_CONNECTED;
 
         m_siLoginServer.m_flServerTime = stream.ReadDouble(); //Time sync
-        m_siLoginServer.m_qwCookie = stream.ReadQWORD();
-        m_siLoginServer.m_wLogicalID = stream.ReadWORD();
+        m_siLoginServer.m_qwCookie = stream.ReadQWORD();  // Connection cookie
+		m_siLoginServer.m_wLogicalID = stream.ReadWORD(); // Client ID for our session
         WORD paddingWord = stream.ReadWORD();
 
         DWORD serverSeed = stream.ReadDWORD();
@@ -718,11 +770,22 @@ void cNetwork::ProcessLSPacket(cPacket *Packet)
 
         DWORD unknownPadding = stream.ReadDWORD();
 
+		m_Interface->SetConnProgress(0.1);
+		// XXX: delay to avoid race condition where server hasn't entered AuthConnectResponse state
+		Sleep(500);
+		m_Interface->SetConnProgress(0.5);
+		m_Interface->OutputConsoleString("Sending connect response...");
+		// Final third step of the connection process is to send connect response packet with cookie
         SendConnectResponse();
-        Sleep(300);
-        SendConnectResponse();
+		m_Interface->SetConnProgress(0.2);
 
         dwFlags &= ~kConnectRequest;
+
+		// login server is world server unless we get a redirect
+		SOCKADDR_IN tpaddr;
+		memcpy(&tpaddr, &m_siLoginServer.m_saServer, sizeof(tpaddr));
+		tpaddr.sin_port = htons(m_siLoginServer.m_wBasePort);
+		AddWorldServer(tpaddr);
     }
     
     if (dwFlags & kNetError1)
@@ -756,9 +819,10 @@ void cNetwork::ProcessLSPacket(cPacket *Packet)
         				break;
         
         			cMessage *scan = *it;
+					/* fragment matches existing sequence we have started receiving */
         			if ( scan->m_dwSequence == fragHead->m_dwSequence)
         			{
-        				scan->AddChunk(fragData, payloadSize, fragHead->m_wIndex);
+						scan->AddChunk(fragData, payloadSize, fragHead->m_wIndex);
         				bAdded = true;
         
         				if ( scan->IsComplete() )
@@ -964,15 +1028,18 @@ void cNetwork::ProcessLSPacket(cPacket *Packet)
 void cNetwork::SendConnectResponse()
 {
     stTransitHeader header;
-    header.m_dwFlags = 0x00080000;
+    header.m_dwFlags = kConnectResponse;
     cPacket *connectReply = new cPacket();
     connectReply->Add(&header, sizeof(header));
     connectReply->Add(m_siLoginServer.m_qwCookie);
     SendLSPacket(connectReply, false, false);
 }
 
+
 void cNetwork::ProcessWSPacket(cPacket *Packet, stServerInfo *Server)
 {
+	// XXX: for now, everything is handled in ProcessLSPacket
+	return ProcessLSPacket(Packet);
 ////	m_Interface->OutputConsoleString("Worldserver Packet...");
 //	stTransitHeader *Head = (stTransitHeader *) Packet->GetData();
 //	BYTE *Data = Packet->GetData() + sizeof(stTransitHeader);
@@ -2634,7 +2701,10 @@ stServerInfo * cNetwork::AddWorldServer(SOCKADDR_IN NewServer)
 	}
 	stServerInfo tpNewServer;
 
-	m_Interface->OutputConsoleString("New Worldserver!  Creating!");
+	m_Interface->OutputConsoleString("Adding World Server: %s:%i",
+									  inet_ntoa(NewServer.sin_addr),
+									  (int)ntohs(NewServer.sin_port));
+
 
 	//fill in tpNewServer struct...
 	memcpy(&tpNewServer.m_saServer, &NewServer, sizeof(SOCKADDR_IN));

--- a/cNetwork.h
+++ b/cNetwork.h
@@ -34,11 +34,22 @@ const float max_sidestep_anim_rate	= 3.0f;
 //    kSigned = 0x40000000
 //};
 
+
+/* server authentication type */
+enum NetAuthType
+{
+	kAuthUndef = 0x00000000,
+	kAuthAccount = 0x00000001,
+	kAuthAccountPassword = 0x00000002,
+	kAuthGlsTicket = 0x40000002
+};
+
+
 enum PacketFlags
 {
     kRetransmission = 0x00000001,
     kEncryptedChecksum = 0x00000002,
-    kBlobFragments = 0x00000004,
+    kBlobFragments = 0x00000004, // Packet contains a fragment of a larger blob
     kServerSwitch = 0x00000100, // CServerSwitchStruct (60, kHighPriority|kCountsAsTouch)
     kUnknown1 = 0x00000200, // CLogonRouteHeader (sockaddr_in) (7, kDisposable|kExclusive|kNotConn)
     kUnknown2 = 0x00000400, // EmptyHeader (7, kDisposable|kExclusive|kNotConn)
@@ -159,7 +170,7 @@ public:
 
 private:
     void SendConnectResponse();
-    
+	
 	cInterface *m_Interface;
 	cObjectDB *m_ObjectDB;
 	cCharInfo *m_CharInfo;
@@ -181,6 +192,7 @@ private:
 	BYTE m_zTicket[0x100];
 	char m_zTicketKey[100];
 	char m_zAccountName[40];
+	char m_zPassword[100];
 
     DWORD m_dwGUIDLogin;
 
@@ -191,3 +203,4 @@ private:
 	// Cache Tell ids
 	std::map< std::string, DWORD >		m_treeNameIDCache;
 };
+

--- a/cPacket.h
+++ b/cPacket.h
@@ -5,6 +5,7 @@ public:
 	cPacket();
 	~cPacket();
 	void Add(std::string & szInput);
+	void AddString32L(std::string & szInput);
     void Add(QWORD qwInput);
     void Add(DWORD dwInput);
     void Add(WORD dwInput);


### PR DESCRIPTION
Fixed the login process so we can get to the character selection screen. Tested using ACE 9318d30.

This required adding password based authentication and String32L support, the login server to the world server list, and a few other things.

No longer using a fixed source port -- we get a random port from the socket API instead.